### PR TITLE
docs: add NPC-only gameplay pacing to vision and roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,6 +106,7 @@ See `M1-ARCH.md` for detailed architectural decisions.
 **Changes:**
 - Background world loop in `server.py` (or new `world.py`): runs on a configurable interval (e.g., every 5–15 minutes real time); spawns NPC-only games when no human games are active; lets them play out a few hands; updates all relationship data
 - NPC "availability" model: each NPC has a `next_available_at` timestamp; world loop picks available NPCs and seats them together, simulating a night at the saloon
+- **NPC-only pacing**: when no human players are at the table, the game runs at a slower, ambient pace — longer delays between hands and actions, so it reads like background conversation rather than active play. New env var `SALOON_NPC_PACE_MULTIPLIER` (default `3.0`) scales `BLACKJACK_TIME_BETWEEN_HANDS` and inter-action delays; the channel stream becomes something players can ignore or tune into for entertainment. Pace returns to normal the moment a human joins.
 - Random world events (small set): NPC goes on winning/losing streak (adjust wallet), NPC gets "restless" (plays more often), NPC has a falling-out with another (relationship type changes)
 - World event log: lightweight `world_events` table (npc_id, event_type, description, occurred_at); last 20 events queryable
 - New `/news` Discord command: shows recent world events in-character ("Word around the saloon: Winifred Cobb cleaned out the table last Tuesday...")

--- a/VISION.md
+++ b/VISION.md
@@ -15,3 +15,5 @@ The pace is deliberate. There's no urgency to rush through hands — the atmosph
 NPCs have lives beyond the table. Each one is generated with a backstory and relationships to other regulars — old friends, rivals, strangers with history. Random events shape them over time, drawing some to the tables more and pushing others away. They form opinions of each other through play, and they'll form opinions of you too. Show up enough, win enough, and word gets around; a notorious player won't get the same game from a sharp-eyed regular as an unknown one would.
 
 The saloon never closes. NPCs keep their habits and their histories whether anyone's at the table or not. Players can pull up a chair — from Discord, the command line, or wherever else — drop into whatever's happening, and leave when they're done. The world doesn't wait for them, and it doesn't stop when they go.
+
+When no humans are present, the pace slows. NPC-only games should feel like background noise — the murmur of a card game in the next room that you can tune out entirely or stop and listen to. Hands take longer, banter lingers. The moment a player sits down, the table snaps back to a normal rhythm.


### PR DESCRIPTION
When no humans are at the table, play should slow to an ambient pace —
background conversation that players can ignore or tune into for
entertainment, snapping back to normal when someone sits down.

Placed in M6 (Autonomous World) with SALOON_NPC_PACE_MULTIPLIER config;
reinforced in VISION.md as a core atmospheric design principle.

https://claude.ai/code/session_019saaRFAo2BfJrRQDUWLSS3